### PR TITLE
Memoization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"liveServer.settings.port": 5501
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.71"
 average = { version = "0.14.1", features = ["rayon"] }
 itertools = "0.11.0"
 js-sys = "0.3.64"
+memoize = "0.4.0"
 ordered-float = "3.7.0"
 pathfinding = "4.3.0"
 regex = "1.9.1"

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ flowchart TB
     Beat1 ~~~ Beat2 ~~~ Beat3 ~~~ Beat4
 ```
 
-With the node links, we can see the directed graph take shape:
+With the node edges, we can see the directed graph take shape:
 
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'basis' } } }%%
@@ -247,8 +247,8 @@ flowchart TB
 
 The number of fingering combinations grows exponentially with more beats and pitches so the choice of [shortest path algorithm](https://en.wikipedia.org/wiki/Shortest_path_problem) is critical. The [Dijkstra](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm) pathfinding algorithm was chosen for this application of the "shortest path exercise" for the following reasons:
 
-- The sequential nature of the musical arrangement problem results in a _directed_ graph where only nodes representing consecutive beat fingering combinations are linked.
-- The links between nodes are _weighted_ with the difficulty of moving from one fingering combination to another graph above is already constructed with the only possible next nodes connected.
+- The sequential nature of the musical arrangement problem results in a _directed_ graph where only nodes representing consecutive beat fingering combinations have edges.
+- The edges between nodes are _weighted_ with the difficulty of moving from one fingering combination to another graph above is already constructed with the only possible next nodes connected.
 
 ## Contributing and Installation
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, Result};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use guitar_tab_generator::{
-    arrangement::{create_arrangements, BeatVec, Line},
+    arrangement::{self, create_arrangements, BeatVec, Line},
     guitar::{create_string_tuning, Guitar, STD_6_STRING_TUNING_OPEN_PITCHES},
     parser::parse_lines,
     pitch::Pitch,
@@ -12,56 +12,6 @@ use guitar_tab_generator::{
 };
 use itertools::Itertools;
 use std::{collections::BTreeMap, time::Duration};
-
-pub fn guitar_creation(c: &mut Criterion) {
-    let six_string_tuning = create_string_tuning(&STD_6_STRING_TUNING_OPEN_PITCHES);
-
-    let three_string_tuning = create_string_tuning(&[Pitch::E4, Pitch::B3, Pitch::G3]);
-    let twelve_string_tuning = create_string_tuning(&[
-        Pitch::E4,
-        Pitch::B3,
-        Pitch::G3,
-        Pitch::D3,
-        Pitch::A2,
-        Pitch::E2,
-        Pitch::E2,
-        Pitch::E2,
-        Pitch::E2,
-        Pitch::E2,
-        Pitch::E2,
-        Pitch::E2,
-    ]);
-
-    const STANDARD_NUM_FRETS: u8 = 18;
-
-    c.bench_function("create_standard_guitar", |b| {
-        b.iter(|| {
-            Guitar::new(
-                black_box(six_string_tuning.clone()),
-                black_box(STANDARD_NUM_FRETS),
-                black_box(0),
-            )
-        })
-    });
-    c.bench_function("create_few_fret_guitar", |b| {
-        b.iter(|| {
-            Guitar::new(
-                black_box(six_string_tuning.clone()),
-                black_box(3),
-                black_box(0),
-            )
-        })
-    });
-    c.bench_function("create_few_string_guitar", |b| {
-        b.iter(|| {
-            Guitar::new(
-                black_box(three_string_tuning.clone()),
-                black_box(STANDARD_NUM_FRETS),
-                black_box(0),
-            )
-        })
-    });
-}
 
 fn fur_elise_input() -> &'static str {
     "E4
@@ -154,70 +104,17 @@ fn fur_elise_input() -> &'static str {
     B3
     C4"
 }
-
-fn fur_elise_lines() -> Result<Vec<Line<BeatVec<Pitch>>>> {
-    guitar_tab_generator::parser::parse_lines(fur_elise_input().to_owned())
-}
-
-fn bench_arrangement_creation(c: &mut Criterion) {
-    let tuning = create_string_tuning(&STD_6_STRING_TUNING_OPEN_PITCHES);
-
-    // c.bench_function("fur_elise_1_arrangement", |b| {
-    //     b.iter(|| {
-    //         create_arrangements(
-    //             black_box(Guitar::new(tuning.clone(), 18, 0).unwrap()),
-    //             black_box(fur_elise_lines().unwrap()),
-    //             black_box(1),
-    //         )
-    //     })
-    // });
-    // c.bench_function("fur_elise_3_arrangements", |b| {
-    //     b.iter(|| {
-    //         create_arrangements(
-    //             black_box(Guitar::new(tuning.clone(), 18, 0).unwrap()),
-    //             black_box(fur_elise_lines().unwrap()),
-    //             black_box(3),
-    //         )
-    //     })
-    // });
-    c.bench_function("fur_elise_5_arrangements", |b| {
-        b.iter(|| {
-            create_arrangements(
-                black_box(Guitar::new(tuning.clone(), 18, 0).unwrap()),
-                black_box(fur_elise_lines().unwrap()),
-                black_box(5),
-            )
-        })
-    });
-}
-
-fn bench_arrangement_scaling(c: &mut Criterion) {
-    let tuning = create_string_tuning(&STD_6_STRING_TUNING_OPEN_PITCHES);
-
-    let mut group = c.benchmark_group("bench_arrangement_scaling");
-    for num in (0..=22) {
-        // group.throughput(Throughput::Bytes(*size as u64));
-        group
-            .sample_size(15)
-            .warm_up_time(Duration::from_secs_f32(2.0));
-        group.bench_with_input(BenchmarkId::from_parameter(num), &num, |b, &num| {
-            b.iter(|| {
-                create_arrangements(
-                    black_box(Guitar::new(tuning.clone(), 18, 0).unwrap()),
-                    black_box(fur_elise_lines().unwrap()),
-                    black_box(num),
-                )
-            });
-        });
-    }
-    group.finish();
+fn fur_elise_lines() -> Vec<Line<BeatVec<Pitch>>> {
+    guitar_tab_generator::parser::parse_lines(fur_elise_input().to_owned()).unwrap()
 }
 
 fn bench_parse_lines(c: &mut Criterion) {
     let fur_elise_input = fur_elise_input();
 
     c.bench_function("parse_lines", |b| {
-        b.iter(|| guitar_tab_generator::parser::parse_lines(fur_elise_input.to_owned()))
+        b.iter(|| {
+            guitar_tab_generator::parser::memoized_original_parse_lines(fur_elise_input.to_owned())
+        })
     });
 }
 
@@ -229,6 +126,142 @@ fn bench_create_string_tuning_offset(c: &mut Criterion) {
             )
         })
     });
+}
+
+fn guitar_creation(c: &mut Criterion) {
+    let six_string_tuning = create_string_tuning(&STD_6_STRING_TUNING_OPEN_PITCHES);
+
+    let three_string_tuning = create_string_tuning(&[Pitch::E4, Pitch::B3, Pitch::G3]);
+    let twelve_string_tuning = create_string_tuning(&[
+        Pitch::E4,
+        Pitch::B3,
+        Pitch::G3,
+        Pitch::D3,
+        Pitch::A2,
+        Pitch::E2,
+        Pitch::E2,
+        Pitch::E2,
+        Pitch::E2,
+        Pitch::E2,
+        Pitch::E2,
+        Pitch::E2,
+    ]);
+
+    const STANDARD_NUM_FRETS: u8 = 18;
+
+    c.bench_function("create_standard_guitar", |b| {
+        b.iter(|| {
+            Guitar::new(
+                black_box(six_string_tuning.clone()),
+                black_box(STANDARD_NUM_FRETS),
+                black_box(0),
+            )
+        })
+    });
+    c.bench_function("create_few_fret_guitar", |b| {
+        b.iter(|| {
+            Guitar::new(
+                black_box(six_string_tuning.clone()),
+                black_box(3),
+                black_box(0),
+            )
+        })
+    });
+    c.bench_function("create_few_string_guitar", |b| {
+        b.iter(|| {
+            Guitar::new(
+                black_box(three_string_tuning.clone()),
+                black_box(STANDARD_NUM_FRETS),
+                black_box(0),
+            )
+        })
+    });
+}
+
+fn bench_arrangement_creation(c: &mut Criterion) {
+    let tuning = create_string_tuning(&STD_6_STRING_TUNING_OPEN_PITCHES);
+
+    c.bench_function("fur_elise_1_arrangement", |b| {
+        b.iter(|| {
+            arrangement::memoized_original_create_arrangements(
+                black_box(Guitar::new(tuning.clone(), 18, 0).unwrap()),
+                black_box(fur_elise_lines()),
+                black_box(1),
+            )
+        })
+    });
+    c.bench_function("fur_elise_3_arrangements", |b| {
+        b.iter(|| {
+            arrangement::memoized_original_create_arrangements(
+                black_box(Guitar::new(tuning.clone(), 18, 0).unwrap()),
+                black_box(fur_elise_lines()),
+                black_box(3),
+            )
+        })
+    });
+    c.bench_function("fur_elise_5_arrangements", |b| {
+        b.iter(|| {
+            arrangement::memoized_original_create_arrangements(
+                black_box(Guitar::new(tuning.clone(), 18, 0).unwrap()),
+                black_box(fur_elise_lines()),
+                black_box(5),
+            )
+        })
+    });
+}
+
+fn bench_arrangement_scaling(c: &mut Criterion) {
+    let tuning = create_string_tuning(&STD_6_STRING_TUNING_OPEN_PITCHES);
+
+    let mut group = c.benchmark_group("bench_arrangement_scaling");
+    for num in (0..=22) {
+        group
+            .sample_size(15)
+            .warm_up_time(Duration::from_secs_f32(2.0));
+        group.bench_with_input(BenchmarkId::from_parameter(num), &num, |b, &num| {
+            b.iter(|| {
+                arrangement::memoized_original_create_arrangements(
+                    black_box(Guitar::new(tuning.clone(), 18, 0).unwrap()),
+                    black_box(fur_elise_lines()),
+                    black_box(num),
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_render_tab(c: &mut Criterion) {
+    let mut group = c.benchmark_group("render_tab");
+
+    let arrangements = create_arrangements(
+        Guitar::default(),
+        parse_lines(fur_elise_input().to_owned()).unwrap(),
+        1,
+    )
+    .unwrap();
+
+    for playback_index in (0..=30).step_by(10) {
+        // group
+        //     .sample_size(20)
+        //     .warm_up_time(Duration::from_secs_f32(3.0));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(playback_index),
+            &playback_index,
+            |b, &playback_index| {
+                b.iter(|| {
+                    render_tab(
+                        black_box(&arrangements[0].lines),
+                        black_box(&Guitar::default()),
+                        black_box(20),
+                        black_box(2),
+                        black_box(Some(playback_index)),
+                    );
+                });
+            },
+        );
+    }
+    group.finish();
 }
 
 fn bench_create_single_composition_scaling(c: &mut Criterion) {
@@ -291,50 +324,17 @@ fn bench_create_single_composition_large_scaling(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_render_tab(c: &mut Criterion) {
-    let mut group = c.benchmark_group("render_tab");
-
-    let arrangements = create_arrangements(
-        Guitar::default(),
-        parse_lines(fur_elise_input().to_owned()).unwrap(),
-        1,
-    )
-    .unwrap();
-
-    for playback_index in (0..=30).step_by(10) {
-        // group
-        //     .sample_size(20)
-        //     .warm_up_time(Duration::from_secs_f32(3.0));
-        group.bench_with_input(
-            BenchmarkId::from_parameter(playback_index),
-            &playback_index,
-            |b, &playback_index| {
-                b.iter(|| {
-                    render_tab(
-                        black_box(&arrangements[0].lines),
-                        black_box(&Guitar::default()),
-                        black_box(20),
-                        black_box(2),
-                        black_box(Some(playback_index)),
-                    );
-                });
-            },
-        );
-    }
-    group.finish();
-}
-
 criterion_group! {
     name=benches;
     config = Criterion::default().noise_threshold(0.05).sample_size(15);
     targets =
+        bench_parse_lines,
+        bench_create_string_tuning_offset,
         guitar_creation,
-        // arrangement_creation,
-        // bench_arrangement_scaling,
-        // parse_lines,
-        // create_string_tuning_offset,
-        // bench_create_single_composition_scaling,
+        bench_arrangement_creation,
+        bench_arrangement_scaling,
+        bench_create_single_composition_scaling,
         bench_create_single_composition_large_scaling,
-        // bench_render_tab
+        bench_render_tab
 }
 criterion_main!(benches);

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -29,7 +29,10 @@ fn main() -> Result<()> {
         A3"
     .to_string();
 
-    let lines: Vec<Line<Vec<Pitch>>> = parse_lines(input)?;
+    let lines: Vec<Line<Vec<Pitch>>> = match parse_lines(input) {
+        Ok(input_lines) => input_lines,
+        Err(e) => return Err(std::sync::Arc::try_unwrap(e).unwrap()),
+    };
 
     let tuning = create_string_tuning(&[
         Pitch::E4,
@@ -46,7 +49,11 @@ fn main() -> Result<()> {
     // dbg!(&guitar);
 
     let num_arrangements = 1;
-    let arrangements = create_arrangements(guitar.clone(), lines, num_arrangements)?;
+    let arrangements = match create_arrangements(guitar.clone(), lines, num_arrangements) {
+        Ok(arrangements) => arrangements,
+        Err(e) => return Err(std::sync::Arc::try_unwrap(e).unwrap()),
+    };
+
     // dbg!(&arrangements);
 
     let tab_width = 20;

--- a/examples/wasm.html
+++ b/examples/wasm.html
@@ -123,7 +123,7 @@
             let endTime = performance.now();
             let duration = (endTime - startTime).toFixed(1);
             console.log(`Arrangement generated in ${duration} milliseconds:`, compositions[0]);
-            console.log(`Tab:\n`, compositions[0].tab);
+            console.log(`Tab:\n${compositions[0].tab}`);
 
             console.log(get_tuning_names());
         });

--- a/src/arrangement.rs
+++ b/src/arrangement.rs
@@ -7,7 +7,7 @@ use average::Mean;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use pathfinding::prelude::yen;
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 #[derive(Debug)]
 pub struct InvalidInput {
@@ -251,20 +251,22 @@ mod test_max_fret_span {
 }
 
 // TODO! Handle duplicate pitches in the same line? BeatVec -> Hashset?
+use memoize::memoize;
+#[memoize(Capacity: 10)]
 pub fn create_arrangements(
     guitar: Guitar,
     input_pitches: Vec<Line<BeatVec<Pitch>>>,
     num_arrangements: u8,
-) -> Result<Vec<Arrangement>> {
+) -> Result<Vec<Arrangement>, Arc<anyhow::Error>> {
     const MAX_NUM_ARRANGEMENTS: u8 = 20;
     match num_arrangements {
         1..=MAX_NUM_ARRANGEMENTS => (),
-        0 => return Err(anyhow!("No arrangements were requested.")),
+        0 => return Err(Arc::new(anyhow!("No arrangements were requested."))),
         _ => {
-            return Err(anyhow!(
+            return Err(Arc::new(anyhow!(
                 "Too many arrangements to calculate. The maximum is {}.",
                 MAX_NUM_ARRANGEMENTS
-            ))
+            )))
         }
     };
 
@@ -320,7 +322,7 @@ pub fn create_arrangements(
     // dbg!(&path_results);
 
     if path_results.is_empty() {
-        return Err(anyhow!("No arrangements could be calculated."));
+        return Err(Arc::new(anyhow!("No arrangements could be calculated.")));
     }
 
     let arrangements = path_results

--- a/src/guitar.rs
+++ b/src/guitar.rs
@@ -1,7 +1,7 @@
 use crate::{arrangement::PitchVec, pitch::Pitch, string_number::StringNumber};
 use anyhow::{anyhow, Result};
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     fmt,
 };
 use strum::IntoEnumIterator;
@@ -58,11 +58,11 @@ pub fn create_string_tuning(open_string_pitches: &[Pitch]) -> BTreeMap<StringNum
         .collect::<BTreeMap<StringNumber, Pitch>>()
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct Guitar {
     pub tuning: BTreeMap<StringNumber, Pitch>,
     pub num_frets: u8,
-    pub range: HashSet<Pitch>,
+    pub range: BTreeSet<Pitch>,
     pub string_ranges: BTreeMap<StringNumber, Vec<Pitch>>,
 }
 impl Default for Guitar {
@@ -91,7 +91,7 @@ impl Guitar {
         }
 
         let range = string_ranges.clone().into_iter().fold(
-            HashSet::new(),
+            BTreeSet::new(),
             |mut all_pitches, string_pitches| {
                 all_pitches.extend(string_pitches.1);
                 all_pitches
@@ -119,7 +119,7 @@ mod test_create_guitar {
         let expected_guitar = Guitar {
             tuning: tuning.clone(),
             num_frets: NUM_FRETS,
-            range: HashSet::from([
+            range: BTreeSet::from([
                 Pitch::E2,
                 Pitch::F2,
                 Pitch::FSharpGFlat2,
@@ -192,7 +192,7 @@ mod test_create_guitar {
         let expected_guitar = Guitar {
             tuning: create_string_tuning(&[Pitch::GSharpAFlat4, Pitch::DSharpEFlat4, Pitch::B3]),
             num_frets: NUM_FRETS - CAPO,
-            range: HashSet::from([
+            range: BTreeSet::from([
                 Pitch::G5,
                 Pitch::D4,
                 Pitch::A5,
@@ -295,7 +295,7 @@ mod test_create_guitar {
         let expected_guitar = Guitar {
             tuning: tuning.clone(),
             num_frets: NUM_FRETS,
-            range: HashSet::from([
+            range: BTreeSet::from([
                 Pitch::E2,
                 Pitch::F2,
                 Pitch::FSharpGFlat2,


### PR DESCRIPTION
# Benchmarking

## Definitions

- The normal benchmark is from commit SHA `234448131310e31d33ed4af31ffe46813ba5044c`.
- The Memoized benchmark is from commit SHA `aee0d75920e1c10108a0e9e81b76823454fdcf77`.

```shell
cargo run --release --example basic
```

### Single Arrangement with simple input

|                         |  Normal | Memoized |       Perc Δ |
| ----------------------- | ------: | -------: | -----------: |
| 1st call runtime        | 3.15 ms |  1.24 ms |     *60.63%* |
| Subsequent call runtime | 2.97 ms | 43.40 µs | ***98.54%*** |
| Perc Δ                  | *5.71%* | *96.50%* |              |

---

### Single Arrangement with "Fur Elise" input

|                         |   Normal |  Memoized |       Perc Δ |
| ----------------------- | -------: | --------: | -----------: |
| 1st call runtime        | 35.74 ms |  13.54 ms |     *62.11%* |
| Subsequent call runtime | 30.22 ms | 238.40 µs | ***99.21%*** |
| Perc Δ                  | *15.44%* |  *98.23%* |              |

---

### Single Arrangement with "Fur Elise" input × 10

|                         |  Normal | Memoized |       Perc Δ |
| ----------------------- | ------: | -------: | -----------: |
| 1st call runtime        |  1.28 s |   1.15 s |     *10.16%* |
| Subsequent call runtime |  1.24 s |  2.38 ms | ***99.81%*** |
| Perc Δ                  | *3.13%* | *99.79%* |              |

---

### Single Arrangement with "Fur Elise" input × 20

|                         |  Normal | Memoized |       Perc Δ |
| ----------------------- | ------: | -------: | -----------: |
| 1st call runtime        | 4.61  s |   4.41 s |      *4.34%* |
| Subsequent call runtime |  4.44 s |  2.97 ms | ***99.93%*** |
| Perc Δ                  | *3.69%* | *99.93%* |              |

---

### 5 Arrangements with "Fur Elise" input

|                         |    Normal |  Memoized |       Perc Δ |
| ----------------------- | --------: | --------: | -----------: |
| 1st call runtime        | 509.66 ms | 507.08 ms |      *0.51%* |
| Subsequent call runtime | 471.14 ms | 584.90 µs | ***99.95%*** |
| Perc Δ                  |   *7.56%* |  *99.88%* |              |
