### PR TITLE
PERF: Index `yen()` successors by node group instead of scanning

### DIFF
--- a/docs/adr/0009-pipeline-stays-single-threaded.md
+++ b/docs/adr/0009-pipeline-stays-single-threaded.md
@@ -1,0 +1,65 @@
+# 0009: Pipeline stays single-threaded; Rayon parallelism rejected
+
+Status: accepted
+Date: 2026-06-05
+
+## Context
+
+The arrangement pipeline's cost is dominated by one step: the `yen()`
+k-shortest-paths search inside `create_arrangements` (`src/arrangement.rs`).
+A single-arrangement run of the Fur Elise benchmark (~85 lines) is ~187 µs.
+Asking for 3 or 5 arrangements jumps to ~20 ms, essentially all of it inside
+`yen()`. The surrounding stages (node-group construction, fingering
+validation, path processing, rendering) are individually µs-range per element.
+
+Whether data parallelism could speed the pipeline up was an open question. A
+`rayon-experimentation` branch (`origin/rayon-experimentation`, final report at
+commit `acbb97d`, `dev/rayon-experiment-report.md`) added Rayon at three
+candidate sites and benchmarked each against the baseline. This ADR records the
+result so the question stays answered without re-running the experiment.
+
+## Decision
+
+Keep the pipeline single-threaded. Do not add Rayon. The experiment branch is
+not merged.
+
+Three sites were parallelized with `par_iter()` and measured on Apple M-series:
+
+| Site | Function | Cold-path result (`fur_elise_1_arrangement`) |
+|------|----------|----------------------------------------------|
+| A | `path_node_groups` construction | 187 µs -> 282 µs (+50%) |
+| B | `validate_fingerings` | -> 315 µs (+68% cumulative) |
+| C | `process_path` + `render_tab` | -> 313 µs (no change vs B) |
+
+The multi-arrangement benchmarks (3 and 5 arrangements, ~20 ms) showed no
+statistically significant change at any site, because their cost is the
+sequential `yen()` step that no candidate site touches.
+
+The cause is structural, not a tuning problem. `yen()` is inherently
+sequential: each of the k paths is found relative to the ones before it, so the
+pipeline has no parallel headroom at the step that actually costs. The three
+candidate sites are all pre- or post-`yen()` and individually fast (µs per
+element), so Rayon's thread-pool spin-up and work-distribution overhead
+(~50-100 µs per `par_iter()` invocation on this hardware) exceeds the work being
+parallelized. The `bench_create_single_composition_scaling` cases that looked
+flat or slightly faster were measuring memoize cache hits plus `render_tab`, not
+the cold computation.
+
+## Consequences
+
+- No Rayon dependency. Keeping it out also avoids a
+  `#[cfg(not(target_arch = "wasm32"))]` split, since Rayon's threads do not
+  cross the WASM boundary without `wasm-bindgen-rayon` and a browser worker
+  pool.
+- The `process_beat` helper extracted during Site B is a clean refactor on its
+  own and could be lifted from the branch independently of the `par_iter()`
+  call. The parallelism is what's rejected, not the extraction.
+- Re-investigating parallelism is only worth it if the workload shape changes:
+  input grows to hundreds of beats with dense chords, per-element fingering work
+  gets much heavier, or WASM threading (`wasm-bindgen-rayon` plus a worker pool)
+  lands and the target becomes browser parallelism rather than wall-clock on one
+  core.
+- The real performance lever, if one is ever needed, is `yen()` itself or the
+  graph feeding it (a tighter difficulty heuristic to prune the search, smaller
+  node-group fan-out, or an earlier search cutoff), not data parallelism over
+  the surrounding stages.

--- a/src/arrangement.rs
+++ b/src/arrangement.rs
@@ -1570,6 +1570,15 @@ mod test_calculate_node_difficulty {
 
         assert_eq!(calculate_node_difficulty(&current_node, &next_node), 410);
     }
+
+    #[test]
+    #[should_panic]
+    fn next_node_start_panics() {
+        // `Node::Start` is only ever the pathfinding source, never a successor. The guard
+        // used to also live in `calc_next_nodes`; after the group-indexing rewrite this is
+        // the only copy, so it is pinned here.
+        calculate_node_difficulty(&Node::Rest { line_index: 0 }, &Node::Start);
+    }
 }
 
 fn process_path(

--- a/src/arrangement.rs
+++ b/src/arrangement.rs
@@ -376,11 +376,9 @@ pub fn create_arrangements(
 
     let num_path_node_groups = path_node_groups.len();
 
-    let path_nodes: Vec<Node> = path_node_groups.into_iter().flatten().collect_vec();
-
     let path_results: Vec<(Vec<Node>, i32)> = yen(
         &Node::Start,
-        |current_node| calc_next_nodes(current_node, &path_nodes),
+        |current_node| calc_next_nodes(current_node, &path_node_groups),
         |current_node| match current_node {
             Node::Start => false,
             Node::Rest { line_index } | Node::Playable { line_index, .. } => {
@@ -1160,11 +1158,14 @@ mod test_calc_fret_span {
 type NodeDifficulty = i32;
 
 /// Calculates the next nodes and their transition difficulties based on the current node
-/// and a list of all path nodes.
+/// and the per-beat node groups.
 ///
 /// Returns a vector of tuples, where each tuple contains a `Node` and the `NodeDifficulty`
 /// of moving to that node.
-fn calc_next_nodes(current_node: &Node, path_nodes: &[Node]) -> Vec<(Node, NodeDifficulty)> {
+fn calc_next_nodes(
+    current_node: &Node,
+    path_node_groups: &[BeatVec<Node>],
+) -> Vec<(Node, NodeDifficulty)> {
     let next_node_index = match current_node {
         Node::Start => 0,
         // `create_arrangements` caps accepted input at `MAX_INPUT_LINES` (`u16::MAX`), so the
@@ -1173,73 +1174,76 @@ fn calc_next_nodes(current_node: &Node, path_nodes: &[Node]) -> Vec<(Node, NodeD
         Node::Rest { line_index } | Node::Playable { line_index, .. } => line_index + 1,
     };
 
-    let next_nodes: Vec<(Node, NodeDifficulty)> = path_nodes
-        .iter()
-        .filter(|&node| {
-            next_node_index
-                == match node {
-                    Node::Start => unreachable!("Start should never be a future node."),
-                    Node::Rest { line_index } | Node::Playable { line_index, .. } => *line_index,
-                }
+    // The graph is layered and a group's position equals its `line_index`, so every successor
+    // is exactly one contiguous group. `.get()` returns `None` past the last layer, where the
+    // old full-list filter naturally returned empty.
+    path_node_groups
+        .get(next_node_index as usize)
+        .map(|group| {
+            group
+                .iter()
+                .map(|next_node| {
+                    (
+                        next_node.clone(),
+                        calculate_node_difficulty(current_node, next_node),
+                    )
+                })
+                .collect_vec()
         })
-        .map(|next_node| {
-            (
-                next_node.clone(),
-                calculate_node_difficulty(current_node, next_node),
-            )
-        })
-        .collect_vec();
-
-    next_nodes
+        .unwrap_or_default()
 }
 #[cfg(test)]
 mod test_calc_next_nodes {
     use super::*;
 
-    fn create_test_path_nodes() -> [Node; 7] {
-        [
-            Node::Playable {
-                line_index: 0,
-                scored_beat_fingering: Rc::new(ScoredBeatFingering {
-                    beat_fingering: vec![],
-                    avg_non_zero_fret: Some(OrderedFloat(0.1)),
-                    non_zero_fret_span: 0,
-                }),
-            },
-            Node::Playable {
-                line_index: 0,
-                scored_beat_fingering: Rc::new(ScoredBeatFingering {
-                    beat_fingering: vec![],
-                    avg_non_zero_fret: Some(OrderedFloat(0.2)),
-                    non_zero_fret_span: 0,
-                }),
-            },
-            Node::Playable {
+    fn create_test_path_node_groups() -> Vec<BeatVec<Node>> {
+        vec![
+            vec![
+                Node::Playable {
+                    line_index: 0,
+                    scored_beat_fingering: Rc::new(ScoredBeatFingering {
+                        beat_fingering: vec![],
+                        avg_non_zero_fret: Some(OrderedFloat(0.1)),
+                        non_zero_fret_span: 0,
+                    }),
+                },
+                Node::Playable {
+                    line_index: 0,
+                    scored_beat_fingering: Rc::new(ScoredBeatFingering {
+                        beat_fingering: vec![],
+                        avg_non_zero_fret: Some(OrderedFloat(0.2)),
+                        non_zero_fret_span: 0,
+                    }),
+                },
+            ],
+            vec![Node::Playable {
                 line_index: 1,
                 scored_beat_fingering: Rc::new(ScoredBeatFingering {
                     beat_fingering: vec![],
                     avg_non_zero_fret: Some(OrderedFloat(1.1)),
                     non_zero_fret_span: 1,
                 }),
-            },
-            Node::Rest { line_index: 2 },
-            Node::Rest { line_index: 3 },
-            Node::Playable {
-                line_index: 4,
-                scored_beat_fingering: Rc::new(ScoredBeatFingering {
-                    beat_fingering: vec![],
-                    avg_non_zero_fret: Some(OrderedFloat(4.1)),
-                    non_zero_fret_span: 4,
-                }),
-            },
-            Node::Playable {
-                line_index: 4,
-                scored_beat_fingering: Rc::new(ScoredBeatFingering {
-                    beat_fingering: vec![],
-                    avg_non_zero_fret: Some(OrderedFloat(4.1)),
-                    non_zero_fret_span: 4,
-                }),
-            },
+            }],
+            vec![Node::Rest { line_index: 2 }],
+            vec![Node::Rest { line_index: 3 }],
+            vec![
+                Node::Playable {
+                    line_index: 4,
+                    scored_beat_fingering: Rc::new(ScoredBeatFingering {
+                        beat_fingering: vec![],
+                        avg_non_zero_fret: Some(OrderedFloat(4.1)),
+                        non_zero_fret_span: 4,
+                    }),
+                },
+                Node::Playable {
+                    line_index: 4,
+                    scored_beat_fingering: Rc::new(ScoredBeatFingering {
+                        beat_fingering: vec![],
+                        avg_non_zero_fret: Some(OrderedFloat(4.1)),
+                        non_zero_fret_span: 4,
+                    }),
+                },
+            ],
         ]
     }
 
@@ -1270,7 +1274,7 @@ mod test_calc_next_nodes {
         .collect_vec();
 
         assert_eq!(
-            calc_next_nodes(&current_node, &create_test_path_nodes()),
+            calc_next_nodes(&current_node, &create_test_path_node_groups()),
             expected_nodes_and_costs
         );
     }
@@ -1298,7 +1302,7 @@ mod test_calc_next_nodes {
         .collect_vec();
 
         assert_eq!(
-            calc_next_nodes(&current_node, &create_test_path_nodes()),
+            calc_next_nodes(&current_node, &create_test_path_node_groups()),
             expected_nodes_and_costs
         );
     }
@@ -1319,7 +1323,7 @@ mod test_calc_next_nodes {
             .collect_vec();
 
         assert_eq!(
-            calc_next_nodes(&current_node, &create_test_path_nodes()),
+            calc_next_nodes(&current_node, &create_test_path_node_groups()),
             expected_nodes_and_costs
         );
     }
@@ -1333,7 +1337,7 @@ mod test_calc_next_nodes {
             .collect_vec();
 
         assert_eq!(
-            calc_next_nodes(&current_node, &create_test_path_nodes()),
+            calc_next_nodes(&current_node, &create_test_path_node_groups()),
             expected_nodes_and_costs
         );
     }
@@ -1364,17 +1368,8 @@ mod test_calc_next_nodes {
         .collect_vec();
 
         assert_eq!(
-            calc_next_nodes(&current_node, &create_test_path_nodes()),
+            calc_next_nodes(&current_node, &create_test_path_node_groups()),
             expected_nodes_and_costs
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn to_start() {
-        calc_next_nodes(
-            &Node::Rest { line_index: 3 },
-            &[Node::Rest { line_index: 4 }, Node::Start],
         );
     }
 }


### PR DESCRIPTION
## Summary

- Replace the O(N) linear scan in `calc_next_nodes` with a direct O(group size) lookup into the per-beat node groups, so the `yen()` adjacency term stops growing as O(k * N^2) on multi-arrangement and long inputs
- Stop flattening `path_node_groups` into a single `path_nodes` Vec. A group's position already equals its `line_index`, so a node's successors are exactly one contiguous group
- Point the `yen()` successor closure at `path_node_groups` and index the one group with `.get(line_index + 1)`, returning empty past the last layer to match the old filter's behavior
- Keep the only remaining `Node::Start`-as-successor guard in `calculate_node_difficulty`, pinned by a new `next_node_start_panics` test, and delete the now-impossible `to_start` test
- Preserve behavior byte-for-byte. The exact-output pins in `test_create_arrangements`, the renderer asserts, and the five `test_calc_next_nodes` cases are the gate

## Benchmarking

Numbers are medians of 3 CI `Benchmark` runs per side (ubuntu-latest, `main` vs this branch). Free runners land on different physical hosts run to run (I saw a ~1.5x spread), so I take the median and check it against control benchmarks that don't touch the rewritten path: `parse_lines`, `render_tab`, and `large_scaling` held within ~3% across the same runs, so the deltas below are the change, not host variance.

Test conditions:
- `fur_elise_{1,3,5}` call `create_arrangements` directly through the `memoized_original_*` escape hatch, so they re-run the rewritten path every iteration.
- `bench_arrangement_scaling/k` sweeps `k` from 1 to 20 (`NumArrangements::MAX`) on a fixed input, isolating the multi-arrangement cost.
- `large_scaling/N` runs the full `parse -> generate -> render` pipeline on Für Elise repeated N times at k=1, through the public `generate_arrangements`. That path is `#[memoize]`d on a constant input, so after the first iteration it returns the cached arrangement and never re-runs the rewritten code. It stays flat by construction (-2.3% to +0.7%, all within noise, no regression).

| Bench | Before (`main`) | After | Δ |
|---|---:|---:|---:|
| `fur_elise_1_arrangement` | 254.94 µs | 176.42 µs | *-30.8%* |
| `fur_elise_3_arrangements` | 21.705 ms | 16.613 ms | *-23.5%* |
| `fur_elise_5_arrangements` | 21.705 ms | 16.685 ms | *-23.1%* |

`bench_arrangement_scaling` holds the same win across the whole sweep: ~-24% for every k from 2 to 20, and -30.9% at k=1.

## Test Plan

- [x] `cargo test` green (222 unit + 30 integration + 2 doctests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] CI `Benchmark` job deltas (ubuntu-latest, `main` vs branch) recorded above
